### PR TITLE
Merge of current beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ All notable changes to this project will be documented in this file. This projec
 - Update to gh-md-toc ( generates TOC for README )
 - Merge current beta functionality into main code base
 - Remove the fake Alexa Contact sensor from discovery and events
-- Enable the usage of websockets instead of mqtt, to provide improved connectivity in some setups
-- New configuration option `wssTransport` which enables the websocket transport
-- Enable the usage of mqtts instead of mqtt, to provide improved connectivity in some setups
-- New configuration option `mqttsTransport` which enables the mqtts transport
+- Enable new cloud transport options `CloudTransport` websockets and mqtts, to provide improved connectivity in some setups. Previously these had been available in the beta.
 - Removed the Alexa contact sensor ( which shows the status of the connection to the cloud servers ) from the list of devices passed to Alexa.
+- Updated and simplified the Homebridge-UI plugin settings menu for homebridge-alexa
 
 ## 0.5.63 (2022-04-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file. This projec
 - Update to gh-md-toc ( generates TOC for README )
 - Merge current beta functionality into main code base
 - Remove the fake Alexa Contact sensor from discovery and events
-- Enable new cloud transport options `CloudTransport` websockets and mqtts, to provide improved connectivity in some setups. Previously these had been available in the beta.
+- Enable ability to change cloud transport `CloudTransport`, to provide improved connectivity in some setups. Previously these had been available in the beta.
 - Removed the Alexa contact sensor ( which shows the status of the connection to the cloud servers ) from the list of devices passed to Alexa.
 - Updated and simplified the Homebridge-UI plugin settings menu for homebridge-alexa
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,16 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
-## 0.5.64 (2022-12-19)
+## 0.6.0 (2023-01-03)
 
-## [Version 0.5.64](https://github.com/northernman54/homebridge-alexa/compare/v0.5.63...v0.5.64)
+## [Version 0.6.0](https://github.com/northernman54/homebridge-alexa/compare/v0.5.63...v0.6.0)
 
 #### Changes
 
 - Added additional debug logging to easily determine child bridge address to aid Homebridge Accessory Dumps
-- Updates to hap-node-client to better support usage of ipv6
+- Updates to hap-node-client to better support usage of ipv6 and removal of request dependancy
 - Update to gh-md-toc ( generates TOC for README )
 - Merge current beta functionality into main code base
-- Remove the fake Alexa Contact sensor from discovery and events
 - Enable ability to change cloud transport `CloudTransport`, to provide improved connectivity in some setups. Previously these had been available in the beta.
 - Removed the Alexa contact sensor ( which shows the status of the connection to the cloud servers ) from the list of devices passed to Alexa.
 - Updated and simplified the Homebridge-UI plugin settings menu for homebridge-alexa

--- a/Installation.md
+++ b/Installation.md
@@ -36,7 +36,7 @@ Installation and Configuration of Homebridge Alexa
    * [Discover Devices](#discover-devices)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:22:54 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:23:10 EST -->
 
 <!--te-->
 

--- a/Installation.md
+++ b/Installation.md
@@ -36,7 +36,7 @@ Installation and Configuration of Homebridge Alexa
    * [Discover Devices](#discover-devices)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:02:41 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:22:54 EST -->
 
 <!--te-->
 

--- a/Installation.md
+++ b/Installation.md
@@ -36,7 +36,7 @@ Installation and Configuration of Homebridge Alexa
    * [Discover Devices](#discover-devices)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Sat 24 Dec 2022 16:52:03 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:02:41 EST -->
 
 <!--te-->
 

--- a/Installation.md
+++ b/Installation.md
@@ -3,44 +3,48 @@ Installation and Configuration of Homebridge Alexa
 
 <!--ts-->
 * [Installation and Configuration of Homebridge Alexa](#installation-and-configuration-of-homebridge-alexa)
-* [Setup Instructions for users of the Homebridge UI](#setup-instructions-for-users-of-the-homebridge-ui)
+* [Setup Instructions](#setup-instructions)
    * [Create Homebridge-Alexa Cloud Services Account](#create-homebridge-alexa-cloud-services-account)
    * [Install and Configure the Plugin](#install-and-configure-the-plugin)
       * [Installation in Homebridge UI](#installation-in-homebridge-ui)
       * [Configuration in Homebridge UI](#configuration-in-homebridge-ui)
    * [Enabling and linking the Homebridge Smart Home Skill](#enabling-and-linking-the-homebridge-smart-home-skill)
       * [Viewing Account Status](#viewing-account-status)
-* [Legacy Setup Instructions for users not using the Homebridge UI, includes advanced configuration options](#legacy-setup-instructions-for-users-not-using-the-homebridge-ui-includes-advanced-configuration-options)
+* [Advanced Setup Instructions, including advanced configuration options](#advanced-setup-instructions-including-advanced-configuration-options)
    * [Prepare Homebridge for plugin installation](#prepare-homebridge-for-plugin-installation)
    * [Install Plugin](#install-plugin)
    * [Create homebridge-alexa account](#create-homebridge-alexa-account)
    * [HomeBridge-alexa plugin configuration](#homebridge-alexa-plugin-configuration)
-      * [Required parameters](#required-parameters)
-      * [Optional parameters](#optional-parameters)
+      * [Required Settings](#required-settings)
+      * [Optional Settings](#optional-settings)
+         * [debug](#debug)
          * [pin](#pin)
          * [routines](#routines)
+         * [deviceList &amp; deviceListHandling - Filtering of devices by name, either allow or allow](#devicelist--devicelisthandling---filtering-of-devices-by-name-either-allow-or-allow)
+      * [Advanced Settings](#advanced-settings)
+         * [CloudTransport - Cloud Server Connection Transport](#cloudtransport---cloud-server-connection-transport)
+         * [keepalive - Cloud Server Connection Keepalive](#keepalive---cloud-server-connection-keepalive)
+         * [refresh - Accessory Cache Refresh Interval](#refresh---accessory-cache-refresh-interval)
+         * [filter - Homebridge Instance Filter](#filter---homebridge-instance-filter)
          * [blind](#blind)
          * [door](#door)
-         * [debug](#debug)
-         * [refresh](#refresh)
-         * [filter](#filter)
-         * [deviceList &amp; deviceListHandling](#devicelist--devicelisthandling)
-         * [combine](#combine)
+      * [Speaker Settings](#speaker-settings)
          * [speakers](#speakers)
+      * [Combine Accessories](#combine-accessories)
+         * [combine](#combine)
          * [Inputs](#inputs)
          * [Apple TV](#apple-tv)
          * [Yamaha Spotify Controls](#yamaha-spotify-controls)
-         * [New Parser](#new-parser)
    * [Initial Testing and confirming configuration](#initial-testing-and-confirming-configuration)
    * [Enable Homebridge smarthome skill and link accounts](#enable-homebridge-smarthome-skill-and-link-accounts)
    * [Discover Devices](#discover-devices)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:23:10 EST -->
+<!-- Added by: sgracey, at: Fri 30 Dec 2022 11:50:45 EST -->
 
 <!--te-->
 
-# Setup Instructions for users of the Homebridge UI
+# Setup Instructions
 
 ## Create Homebridge-Alexa Cloud Services Account
 
@@ -70,7 +74,7 @@ In the Amazon Alexa Application on your smart phone, search for the Homebridge S
 
 On the homebridge.ca website you can view your account status, and identify any setup issues.
 
-# Legacy Setup Instructions for users not using the Homebridge UI, includes advanced configuration options
+# Advanced Setup Instructions, including advanced configuration options
 
 * If you are looking for a basic setup to get this plugin up and running check out this guide (https://sambrooks.net/controlling-homebridge-using-alexa/).  And here is another setup guide (https://www.youtube.com/watch?v=Ylg4yiw8ofM).
 
@@ -163,12 +167,28 @@ sudo npm install -g homebridge-alexa
 ],
 ```
 
-### Required parameters
+### Required Settings
 
+* name - Plugin name as displayed in the Homebridge log
 * username - Login created for the skill linking website https://www.homebridge.ca/
 * password - Login created for the skill linking website https://www.homebridge.ca/
 
-### Optional parameters
+### Optional Settings
+
+#### debug
+  - This enables debug logging mode, can be used instead of the command line option ( DEBUG=* homebridge )
+
+```
+"platforms": [
+  {
+    "platform": "Alexa",
+    "name": "Alexa",
+    "username": "....",
+    "password": "....",
+    "debug": true
+  }
+],
+```
 
 #### pin
   - If you had changed your homebridge pin from the default of "pin": "031-45-154" ie
@@ -186,7 +206,7 @@ sudo npm install -g homebridge-alexa
 ```
 
 #### routines
-  - Enables passing to Alexa of real time events from Motion and Contact sensors. For use in the Alexa app to create Routines triggered by these sensors.  Not required unless you are using Alexa Routines.
+  - Enables passing to Alexa of real time events from Motion and Contact sensors. For use in the Alexa app to create Routines triggered by these sensors.  Not required unless you are using Alexa Routines triggered by Homebridge devices.
 
 ```
 "platforms": [
@@ -196,6 +216,92 @@ sudo npm install -g homebridge-alexa
     "username": "....",
     "password": "....",
     "routines": true
+  }
+],
+```
+
+#### deviceList & deviceListHandling - Filtering of devices by name, either allow or allow
+  - allow or deny devices by name to be exposed to alexa.  Values are checked to see if they are contained within the name.  ( Under the covers it is using regex, so more complex options are available )
+
+```
+"platforms": [
+  {
+  "platform": "Alexa",
+  "name": "Alexa",
+  "username": "....",
+  "password": "....",
+  "deviceListHandling": "deny",   // or allow
+  "deviceList":
+    [
+      "LightBulb",
+      "GarageDoor",
+      "SecureDevice"
+    ]
+  }
+],
+```
+
+### Advanced Settings
+
+#### CloudTransport - Cloud Server Connection Transport
+
+- Transport options for cloud server connection. MQTTS - this is the recommended setting. MQTT - this is the original/legacy option. WSS - this is the an alternative transport option.
+
+```
+"platforms": [
+  {
+    "platform": "Alexa",
+    "name": "Alexa",
+    "username": "....",
+    "password": "....",
+    "CloudTransport": "mqtts"
+  }
+],
+```
+
+#### keepalive - Cloud Server Connection Keepalive
+
+- Frequency of keepalive messages to cloud server, in minutes. Defaults to 5 minutes.  Do not change from default unless requested as part of problem investigation.
+
+```
+"platforms": [
+  {
+    "platform": "Alexa",
+    "name": "Alexa",
+    "username": "....",
+    "password": "....",
+    "keepalive": 5
+  }
+],
+```
+
+#### refresh - Accessory Cache Refresh Interval
+
+- Frequency of refreshes of the homebridge accessory cache, in seconds. Defaults to 900 Seconds ( 15 minutes ). This is the interval before new devices/homebridge instances are discovered.  This should never require changing, unless you are frequently changing your homebridge configuration without restarting the plugin.
+
+```
+"platforms": [
+  {
+    "platform": "Alexa",
+    "name": "Alexa",
+    "username": "....",
+    "password": "....",
+    "refresh": 900
+  }
+],
+```
+
+#### filter - Homebridge Instance Filter
+  - Limits accessories shared with Alexa to a single homebridge instance.  ( I'm using this setting with Amazon for skill testing. ).  The setting is ip:port of homebridge instance.
+
+```
+"platforms": [
+  {
+    "platform": "Alexa",
+    "name": "Alexa",
+    "username": "....",
+    "password": "....",
+    "filter": "192.168.1.122:51826"
   }
 ],
 ```
@@ -230,101 +336,10 @@ sudo npm install -g homebridge-alexa
 ],
 ```
 
-#### debug
-  - This enables debug logging mode, can be used instead of the command line option ( DEBUG=* homebridge )
-
-```
-"platforms": [
-  {
-    "platform": "Alexa",
-    "name": "Alexa",
-    "username": "....",
-    "password": "....",
-    "debug": true
-  }
-],
-```
-
-#### refresh
-  - Frequency of refreshes of the homebridge accessory cache, in seconds.  Defaults to 15 minutes.
-
-```
-"platforms": [
-  {
-    "platform": "Alexa",
-    "name": "Alexa",
-    "username": "....",
-    "password": "....",
-    "refresh": 900
-  }
-],
-```
-
-#### filter
-  - Limits accessories shared with Alexa to a single homebridge instance.  ( I'm using this setting with Amazon for skill testing. ).  The setting is ip:port of homebridge instance.
-
-```
-"platforms": [
-  {
-    "platform": "Alexa",
-    "name": "Alexa",
-    "username": "....",
-    "password": "....",
-    "filter": "192.168.1.122:51826"
-  }
-],
-```
-
-#### deviceList & deviceListHandling
-  - allow or deny devices by name to be exposed to alexa.  Values are checked to see if they are contained within the name.  ( Under the covers it is using regex, so more complex options are available )
-
-```
-"platforms": [
-  {
-  "platform": "Alexa",
-  "name": "Alexa",
-  "username": "....",
-  "password": "....",
-  "deviceListHandling": "deny",   // or allow
-  "deviceList":
-    [
-      "LightBulb",
-      "GarageDoor",
-      "SecureDevice"
-    ]
-  }
-],
-```
-
-#### combine
-  - Combine disparate accessories into one common device.  My example here is combining my TV Remote (KODI), which only has ON/OFF and Volume controls into the Apple TV (TV) playback controls. And combining the spotify controls from my Yamaha receiver into the Zone.
-
-```
-"platforms": [
-  {
-    "platform": "Alexa",
-    "name": "Alexa",
-    "username": "....",
-    "password": "....",
-    "combine": [{
-          "into": "TV",
-          "from": ["KODI", "Power (TV)"]
-        }, {
-          "into": "Front",
-          "from": ["Yamaha"]
-        }, {
-          "into": "Rear",
-          "from": ["Yamaha"]
-        }],
-  }
-],
-```
-
-* into - Device name to combine into
-* from - Device name to combine from, can be a list of multiple devices.
-
+### Speaker Settings
 
 #### speakers
+
   - Devices to configure as speakers as HomeKit currently does not have a Speaker service, and enable the alexa phase `Alexa, raise the volume on`.
 
 ```
@@ -367,6 +382,39 @@ ie
     ]
   }
 ```
+
+### Combine Accessories
+
+
+#### combine
+  - Combine disparate accessories into one common device.  My example here is combining my TV Remote (KODI), which only has ON/OFF and Volume controls into the Apple TV (TV) playback controls. And combining the spotify controls from my Yamaha receiver into the Zone.
+
+```
+"platforms": [
+  {
+    "platform": "Alexa",
+    "name": "Alexa",
+    "username": "....",
+    "password": "....",
+    "combine": [{
+          "into": "TV",
+          "from": ["KODI", "Power (TV)"]
+        }, {
+          "into": "Front",
+          "from": ["Yamaha"]
+        }, {
+          "into": "Rear",
+          "from": ["Yamaha"]
+        }],
+  }
+],
+```
+
+* into - Device name to combine into
+* from - Device name to combine from, can be a list of multiple devices.
+
+
+
 
 #### Inputs
 
@@ -503,15 +551,6 @@ Also to enable turning on and off your Apple TV, add this to your homebridge-ale
 
 This uses the plugin homebridge-yamaha-home and a Yamaha Receiver which includes Spotify and Spotify Playback Controls.
 
-#### New Parser
-
-~~As of April 14, 2019 I changed the Homebridge device parser massively, to add support for Locks and Heater/Cooler devices.  To go back to the old device parser, you can set an option oldParser to true.  Default is to the new parser.~~
-
-```
-"oldParser": true
-```
-
-Support for the oldParser option was **deprecated** with version 0.5.0
 
 ## Initial Testing and confirming configuration
 

--- a/Installation.md
+++ b/Installation.md
@@ -36,7 +36,7 @@ Installation and Configuration of Homebridge Alexa
    * [Discover Devices](#discover-devices)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Sun 18 Dec 2022 19:34:09 EST -->
+<!-- Added by: sgracey, at: Sat 24 Dec 2022 16:52:03 EST -->
 
 <!--te-->
 

--- a/Installation.md
+++ b/Installation.md
@@ -40,7 +40,7 @@ Installation and Configuration of Homebridge Alexa
    * [Discover Devices](#discover-devices)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Fri 30 Dec 2022 11:50:45 EST -->
+<!-- Added by: sgracey, at: Tue  3 Jan 2023 10:31:08 EST -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Country availability - The plugin is available in these countries, English (AU),
 <!--ts-->
 * [Note to users of the service](#note-to-users-of-the-service)
    * [New Users](#new-users)
-   * [Existing Users ( Prior to March 26th, 2022 )](#existing-users--prior-to-march-26th-2022-)
 * [Availability](#availability)
 * [Features](#features)
 * [Table of Contents](#table-of-contents)
@@ -84,7 +83,7 @@ Country availability - The plugin is available in these countries, English (AU),
 * [Credits](#credits)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Fri 30 Dec 2022 11:50:44 EST -->
+<!-- Added by: sgracey, at: Tue  3 Jan 2023 10:31:06 EST -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Country availability - The plugin is available in these countries, English (AU),
 * [Credits](#credits)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:22:53 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:23:09 EST -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Country availability - The plugin is available in these countries, English (AU),
 * [Credits](#credits)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:23:09 EST -->
+<!-- Added by: sgracey, at: Fri 30 Dec 2022 11:50:44 EST -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,9 @@ The ongoing costs to run and support the cloud services have grown to the point 
 
 For the subscription model, we have set this up with PayPal to start with, and with a price cheaper than a cup of Starbucks coffee. We thought a coffee a month was a reasonable contribution for the continued delivery of service.
 
-For the migration of users to the new model I’m doing this in two phases, first being new users of the service and the second being existing or legacy users of the service.
-
 ## New Users
 
 For new users of the service, they will receive a trial account, with 7 days of service to test out the service and work thru any issues prior to a subscription being required to continue service.  During the trial period users can apply for a subscription at any time, and it will be future dated to start on the trial period end date. 
-
-## Existing Users ( Prior to March 26th, 2022 )
-
-For existing ‘legacy’ users of the service I have initiated the transition into subscriptions for all users, with a subscription being required after a date between May 25th, 2022 and June 25th, 2022.  If you login to the homebridge.ca website, you can see your start date.  You can signup for subscriptions at any time, and the first payment date will be future dated to the start date.
-
-If you have any questions or concerns, please let me know.
 
 # Availability
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Country availability - The plugin is available in these countries, English (AU),
 * [Credits](#credits)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Sat 24 Dec 2022 16:52:03 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:02:40 EST -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Country availability - The plugin is available in these countries, English (AU),
 * [Credits](#credits)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Sun 18 Dec 2022 19:34:08 EST -->
+<!-- Added by: sgracey, at: Sat 24 Dec 2022 16:52:03 EST -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Country availability - The plugin is available in these countries, English (AU),
 * [Credits](#credits)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:02:40 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:22:53 EST -->
 
 <!--te-->
 

--- a/Troubleshooting.MD
+++ b/Troubleshooting.MD
@@ -34,7 +34,7 @@
    * [[Alexa] ERROR:  Event gateway token refresh error: 400](#alexa-error--event-gateway-token-refresh-error-400)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:02:41 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:22:53 EST -->
 
 <!--te-->
 

--- a/Troubleshooting.MD
+++ b/Troubleshooting.MD
@@ -34,7 +34,7 @@
    * [[Alexa] ERROR:  Event gateway token refresh error: 400](#alexa-error--event-gateway-token-refresh-error-400)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:23:09 EST -->
+<!-- Added by: sgracey, at: Fri 30 Dec 2022 11:50:45 EST -->
 
 <!--te-->
 

--- a/Troubleshooting.MD
+++ b/Troubleshooting.MD
@@ -34,7 +34,7 @@
    * [[Alexa] ERROR:  Event gateway token refresh error: 400](#alexa-error--event-gateway-token-refresh-error-400)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Sun 18 Dec 2022 19:34:09 EST -->
+<!-- Added by: sgracey, at: Sat 24 Dec 2022 16:52:03 EST -->
 
 <!--te-->
 

--- a/Troubleshooting.MD
+++ b/Troubleshooting.MD
@@ -34,7 +34,7 @@
    * [[Alexa] ERROR:  Event gateway token refresh error: 400](#alexa-error--event-gateway-token-refresh-error-400)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Fri 30 Dec 2022 11:50:45 EST -->
+<!-- Added by: sgracey, at: Tue  3 Jan 2023 10:31:07 EST -->
 
 <!--te-->
 

--- a/Troubleshooting.MD
+++ b/Troubleshooting.MD
@@ -34,7 +34,7 @@
    * [[Alexa] ERROR:  Event gateway token refresh error: 400](#alexa-error--event-gateway-token-refresh-error-400)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:22:53 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:23:09 EST -->
 
 <!--te-->
 

--- a/Troubleshooting.MD
+++ b/Troubleshooting.MD
@@ -34,7 +34,7 @@
    * [[Alexa] ERROR:  Event gateway token refresh error: 400](#alexa-error--event-gateway-token-refresh-error-400)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: sgracey, at: Sat 24 Dec 2022 16:52:03 EST -->
+<!-- Added by: sgracey, at: Tue 27 Dec 2022 22:02:41 EST -->
 
 <!--te-->
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -3,7 +3,7 @@
   "pluginType": "platform",
   "singular": true,
   "headerDisplay": "<h1><p align='center'>Allow your Amazon Alexa to control your homebridge devices</H1></p><h1><p align='center'> <img width='18%' src='https://user-images.githubusercontent.com/19808920/210089307-7622bb91-49d0-4d90-b2c3-31118e1a76c0.png'><b> => </b><img width='20%' src='https://user-images.githubusercontent.com/19808920/210090318-9e8ddc2a-a025-40ac-9718-7b5a2aa9a518.png'></p></h1> <br>To setup the service:<br>1 - First <b>create</b> an account on <a href='https://www.homebridge.ca/'>https://www.homebridge.ca/</a>.  <br>2 - Then <b>enter</b> the username and password for your account <b>below</b>.  <br>3 - <b>Save</b> the settings and <b>restart</b> homebridge.  <br>4 - In the Amazon Alexa Application on your smart phone, <b>search</b> for the Homebridge Skill and enable it.  When you enable the skill, it will take you to the <b>https://www.homebridge.ca/</b> website to <b>enable</b> and link the skill to the plugin.  <br>5 - You can now ask Alexa to <b>`discover devices`</b> and it should discover your homebridge devices.<br><br>Detailed setup instructions are available <a href='https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md#setup-instructions'>here</a>.",
-  "footerDisplay": "Homebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
+  "footerDisplay": "Homebridge Alexa Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
   "schema": {
     "type": "object",
     "properties": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,8 +2,8 @@
   "pluginAlias": "Alexa",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "Allow your Alexa to control your homebridge devices.  Prior to setting up the plugin you need to create an account on https://www.homebridge.ca/ to link your Amazon Alexa account with the plugin. This account will be used when you enable the skill in the Alexa App, and in the configuration below.",
-  "footerDisplay": "See https://github.com/NorthernMan54/homebridge-alexa for more information and instructions.\n\nHomebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
+  "headerDisplay": "<h1>Allow your Amazon Alexa to control your homebridge devices</H1>. <br>Detailed setup instructions are [here](https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md). <br><br>Prior to setting up the plugin you need to create an account on https://www.homebridge.ca/ to link your Amazon Alexa account with the plugin. This account will be used when you enable the skill in the Alexa App, and in the configuration below.",
+  "footerDisplay": "See https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md for more information and instructions.\n\nHomebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
   "schema": {
     "type": "object",
     "properties": {
@@ -53,10 +53,12 @@
         "default": false
       },
       "refresh": {
-        "title": "Refresh Interval",
+        "title": "Accessory Cache Refresh Interval",
         "type": "integer",
-        "placeholder": "900",
-        "description": "Frequency of refreshes of the homebridge accessory cache, in seconds. Defaults to 15 minutes."
+        "default": 900,
+        "description": "Frequency of refreshes of the homebridge accessory cache, in seconds. Defaults to 900 Seconds ( 15 minutes ). This is the interval before new devices/homebridge instances are discovered.  This should never require changing, unless you are frequently changing your homebridge configuration without restarting the plugin.",
+        "minimum": 120,
+        "maximum": 86400
       },
       "keepalive": {
         "title": "Cloud Server Connection Keepalive",
@@ -64,34 +66,56 @@
         "placeholder": "5",
         "description": "Frequency of keepalive messages to cloud server, in minutes. Defaults to 5 minutes.  Do not change from default unless requested as part of problem investigation.",
         "minimum": 1,
-        "maximum": 59
+        "maximum": 59,
+        "condition": {
+          "functionBody": "return model.CloudTransport !== 'wss';"
+        }
       },
-      "wssTransport": {
-        "title": "Websocket Cloud Server Connection",
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Websocket based Cloud Server Connection, this is an alternative to the mqtt based transport. Do not change from default unless requested as part of problem investigation."
-      },
-      "mqttsTransport": {
-        "title": "MQTTS Cloud Server Connection",
-        "type": "boolean",
-        "default": false,
-        "description": "Enable MQTTS based Cloud Server Connection, this is an alternative to the mqtt based transport. Do not change from default unless requested as part of problem investigation."
+      "CloudTransport": {
+        "title": "Cloud Server Connection Transport",
+        "description": "Transport options for cloud server connection. MQTTS - this is the recommended setting. MQTT - this is the original/legacy option. WSS - this is the an alternative transport option.",
+        "type": "string",
+        "default": "mqtts",
+        "oneOf": [
+          {
+            "title": "MQTTS",
+            "enum": [
+              "mqtts"
+            ]
+          },
+          {
+            "title": "WSS",
+            "enum": [
+              "wss"
+            ]
+          },
+          {
+            "title": "MQTT",
+            "enum": [
+              "mqtt"
+            ]
+          }
+        ]
       },
       "filter": {
-        "title": "Instance Filter",
+        "title": "Homebridge Instance Filter",
         "type": "string",
         "placeholder": "eg. 192.168.1.122:51826",
         "description": "Limits accessories shared with Alexa to a single homebridge instance.",
         "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$"
       },
-
       "deviceListHandling": {
-        "title": "How to handle devices in the deviceList",
+        "title": "<b>Filtering of devices by name, either allow or ignore.</b>",
         "type": "string",
+        "default": "none",
         "required": true,
-        "default": "allow",
         "oneOf": [
+          {
+            "title": "None",
+            "enum": [
+              "none"
+            ]
+          },
           {
             "title": "Allow devices",
             "enum": [
@@ -111,6 +135,9 @@
         "type": "array",
         "items": {
           "type": "string"
+        },
+        "condition": {
+          "functionBody": "return model.deviceListHandling !== 'null';"
         }
       },
       "combine": {
@@ -175,16 +202,17 @@
         "pin",
         "routines",
         "debug",
-        "refresh",
-        "filter",
         "deviceListHandling",
         {
           "key": "deviceList",
           "type": "array",
           "items": {
             "title": "DeviceName",
-            "description": "Name of the device you want to ignore",
+            "description": "Name of the device you want to allow or ignore",
             "type": "string"
+          },
+          "condition": {
+            "functionBody": "return model.deviceListHandling !== 'none';"
           }
         }
       ]
@@ -195,9 +223,10 @@
       "expandable": true,
       "expanded": false,
       "items": [
+        "CloudTransport",
         "keepalive",
-        "wssTransport",
-        "mqttsTransport"
+        "refresh",
+        "filter"
       ]
     },
     {
@@ -262,7 +291,6 @@
                     {
                       "title": "From",
                       "key": "combine[].from[]",
-
                       "placeholder": "Source Accessory Name"
                     }
                   ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,8 +2,8 @@
   "pluginAlias": "Alexa",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "<h1>Allow your Amazon Alexa to control your homebridge devices</H1> <br>Detailed setup instructions are https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md . <br><br>Prior to setting up the plugin you need to create an account on https://www.homebridge.ca/ to link your Amazon Alexa account with the plugin. This account will be used when you enable the skill in the Alexa App, and in the configuration below.",
-  "footerDisplay": "See https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md for more information and instructions.\n\nHomebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
+  "headerDisplay": "<h1><p align='center'>Allow your Amazon Alexa to control your homebridge devices</H1></p><h1><p align='center'> <img width='18%' src='https://user-images.githubusercontent.com/19808920/210089307-7622bb91-49d0-4d90-b2c3-31118e1a76c0.png'><b> => </b><img width='20%' src='https://user-images.githubusercontent.com/19808920/210090318-9e8ddc2a-a025-40ac-9718-7b5a2aa9a518.png'></p></h1> <br>To setup the service:<br>1 - First <b>create</b> an account on <a href='https://www.homebridge.ca/'>https://www.homebridge.ca/</a>.  <br>2 - Then <b>enter</b> the username and password for your account <b>below</b>.  <br>3 - <b>Save</b> the settings and <b>restart</b> homebridge.  <br>4 - In the Amazon Alexa Application on your smart phone, <b>search</b> for the Homebridge Skill and enable it.  When you enable the skill, it will take you to the https://www.homebridge.ca/ website to <b>enable</b> and link the skill to the plugin.  <br>5 - You can now ask Alexa to <b>`discover devices`</b> and it should discover your homebridge devices.<br><br>Detailed setup instructions are available <a href='https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md#setup-instructions'>here</a>.",
+  "footerDisplay": "Homebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
   "schema": {
     "type": "object",
     "properties": {
@@ -48,7 +48,7 @@
         "default": false
       },
       "debug": {
-        "title": " Enable Debug Mode",
+        "title": "Enable debug level logging to assist in problem investigation",
         "type": "boolean",
         "default": false
       },
@@ -181,15 +181,20 @@
     }
   },
   "layout": [
-    "name",
     {
-      "type": "flex",
-      "flex-flow": "row wrap",
+      "type": "fieldset",
+      "title": "Required Settings",
       "items": [
-        "username",
         {
-          "key": "password",
-          "type": "password"
+          "type": "flex",
+          "flex-flow": "row wrap",
+          "items": [
+            "username",
+            {
+              "key": "password",
+              "type": "password"
+            }
+          ]
         }
       ]
     },

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,7 +2,7 @@
   "pluginAlias": "Alexa",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "<h1><p align='center'>Allow your Amazon Alexa to control your homebridge devices</H1></p><h1><p align='center'> <img width='18%' src='https://user-images.githubusercontent.com/19808920/210089307-7622bb91-49d0-4d90-b2c3-31118e1a76c0.png'><b> => </b><img width='20%' src='https://user-images.githubusercontent.com/19808920/210090318-9e8ddc2a-a025-40ac-9718-7b5a2aa9a518.png'></p></h1> <br>To setup the service:<br>1 - First <b>create</b> an account on <a href='https://www.homebridge.ca/'>https://www.homebridge.ca/</a>.  <br>2 - Then <b>enter</b> the username and password for your account <b>below</b>.  <br>3 - <b>Save</b> the settings and <b>restart</b> homebridge.  <br>4 - In the Amazon Alexa Application on your smart phone, <b>search</b> for the Homebridge Skill and enable it.  When you enable the skill, it will take you to the https://www.homebridge.ca/ website to <b>enable</b> and link the skill to the plugin.  <br>5 - You can now ask Alexa to <b>`discover devices`</b> and it should discover your homebridge devices.<br><br>Detailed setup instructions are available <a href='https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md#setup-instructions'>here</a>.",
+  "headerDisplay": "<h1><p align='center'>Allow your Amazon Alexa to control your homebridge devices</H1></p><h1><p align='center'> <img width='18%' src='https://user-images.githubusercontent.com/19808920/210089307-7622bb91-49d0-4d90-b2c3-31118e1a76c0.png'><b> => </b><img width='20%' src='https://user-images.githubusercontent.com/19808920/210090318-9e8ddc2a-a025-40ac-9718-7b5a2aa9a518.png'></p></h1> <br>To setup the service:<br>1 - First <b>create</b> an account on <a href='https://www.homebridge.ca/'>https://www.homebridge.ca/</a>.  <br>2 - Then <b>enter</b> the username and password for your account <b>below</b>.  <br>3 - <b>Save</b> the settings and <b>restart</b> homebridge.  <br>4 - In the Amazon Alexa Application on your smart phone, <b>search</b> for the Homebridge Skill and enable it.  When you enable the skill, it will take you to the <b>https://www.homebridge.ca/</b> website to <b>enable</b> and link the skill to the plugin.  <br>5 - You can now ask Alexa to <b>`discover devices`</b> and it should discover your homebridge devices.<br><br>Detailed setup instructions are available <a href='https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md#setup-instructions'>here</a>.",
   "footerDisplay": "Homebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
   "schema": {
     "type": "object",
@@ -33,24 +33,24 @@
         "description": "This needs to match the Homebridge pin set in your config.json file"
       },
       "routines": {
-        "title": " Routines - enables passing to Alexa events from Motion and Contact sensors. For use in the Alexa app to create Routines triggered by these sensors.",
+        "title": " Routines - enables passing of Motion and Contact sensor events to Alexa. For use in the Alexa app to create Routines triggered by these sensors.",
         "type": "boolean",
-        "default": false
+        "placeholder": false
       },
       "blind": {
         "title": "Enables natural wording for opening and closing blinds, and window coverings.  Not supported in all countries.  Defaults to false",
         "type": "boolean",
-        "default": false
+        "placeholder": false
       },
       "door": {
         "title": "Enables natural wording for opening and closing garage doors.  Not supported in all countries.  Please note that opening a garage door requires setting a voice pin within the Alexa app.  Defaults to false",
         "type": "boolean",
-        "default": false
+        "placeholder": false
       },
       "debug": {
         "title": "Enable debug level logging to assist in problem investigation",
         "type": "boolean",
-        "default": false
+        "placeholder": false
       },
       "refresh": {
         "title": "Accessory Cache Refresh Interval",
@@ -76,6 +76,7 @@
         "description": "Transport options for cloud server connection. MQTTS - this is the recommended setting. MQTT - this is the original/legacy option. WSS - this is the an alternative transport option.",
         "type": "string",
         "default": "mqtts",
+        "required": true,
         "oneOf": [
           {
             "title": "MQTTS",

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,7 +2,7 @@
   "pluginAlias": "Alexa",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "<h1>Allow your Amazon Alexa to control your homebridge devices</H1>. <br>Detailed setup instructions are [here](https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md). <br><br>Prior to setting up the plugin you need to create an account on https://www.homebridge.ca/ to link your Amazon Alexa account with the plugin. This account will be used when you enable the skill in the Alexa App, and in the configuration below.",
+  "headerDisplay": "<h1>Allow your Amazon Alexa to control your homebridge devices</H1> <br>Detailed setup instructions are https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md . <br><br>Prior to setting up the plugin you need to create an account on https://www.homebridge.ca/ to link your Amazon Alexa account with the plugin. This account will be used when you enable the skill in the Alexa App, and in the configuration below.",
   "footerDisplay": "See https://github.com/NorthernMan54/homebridge-alexa/blob/master/Installation.md for more information and instructions.\n\nHomebridge Alex Skill: https://www.amazon.com/Northern-Man-54-Homebridge/dp/B07B9QMTFQ",
   "schema": {
     "type": "object",
@@ -63,7 +63,7 @@
       "keepalive": {
         "title": "Cloud Server Connection Keepalive",
         "type": "integer",
-        "placeholder": "5",
+        "default": "5",
         "description": "Frequency of keepalive messages to cloud server, in minutes. Defaults to 5 minutes.  Do not change from default unless requested as part of problem investigation.",
         "minimum": 1,
         "maximum": 59,

--- a/lib/alexaLocal.js
+++ b/lib/alexaLocal.js
@@ -51,7 +51,7 @@ function alexaLocal(options) {
   username = options.mqttOptions.username;
   connection.client = mqtt.connect(options.mqttURL, options.mqttOptions);
   connection.client.on('connect', function () {
-    debug('connect', "command/" + username + "/#");
+    debug('connect', options.mqttURL, "command/" + username + "/#");
     if (options.alexaService) {
       options.alexaService.setCharacteristic(Characteristic.ContactSensorState, Characteristic.ContactSensorState.CONTACT_DETECTED);
     }

--- a/lib/parse/messages.js
+++ b/lib/parse/messages.js
@@ -27,7 +27,7 @@ function createMessageId() {
   var d = new Date().getTime();
 
   var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
-    function(c) {
+    function (c) {
       var r = (d + Math.random() * 16) % 16 | 0;
       d = Math.floor(d / 16);
       return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
@@ -170,10 +170,10 @@ function stateToProperties(statusObject, hbResponse) {
           "uncertaintyInMilliseconds": 500
         });
         break;
-        // Characteristic.LockCurrentState.UNSECURED = 0;
-        // Characteristic.LockCurrentState.SECURED = 1;
-        // Characteristic.LockCurrentState.JAMMED = 2;
-        // Characteristic.LockCurrentState.UNKNOWN = 3;
+      // Characteristic.LockCurrentState.UNSECURED = 0;
+      // Characteristic.LockCurrentState.SECURED = 1;
+      // Characteristic.LockCurrentState.JAMMED = 2;
+      // Characteristic.LockCurrentState.UNKNOWN = 3;
       case "alexa.lockcontroller":
         properties.push({
           "namespace": "Alexa.LockController",
@@ -255,7 +255,7 @@ function mergeCookies(into, from) {
         into[cookie] = JSON.stringify(temp);
         break;
       default:
-        // debug("Not merging cookie", cookie);
+      // debug("Not merging cookie", cookie);
     }
   }
 }
@@ -297,7 +297,7 @@ function mergeCapabilities(into, from) {
         // debug("after", JSON.stringify(into));
         break;
       default:
-        // debug("Not merging capability", from[capability].interface);
+      // debug("Not merging capability", from[capability].interface);
     }
   }
 }
@@ -308,7 +308,7 @@ function lookupCapabilities(capability, options, operations, devices) {
     case "PlaybackController":
       // debug("operations", Object.keys(operations));
       var supported = Object.keys(operations);
-      supported = supported.filter(function(item) {
+      supported = supported.filter(function (item) {
         return item !== 'ReportState';
       });
       // debug("supported", supported);
@@ -335,7 +335,7 @@ function lookupCapabilities(capability, options, operations, devices) {
       break;
     case "Input Source":
       var supported = Object.keys(operations);
-      supported = supported.filter(function(item) {
+      supported = supported.filter(function (item) {
         return item.substring(0, 10) !== 'Station - ';
       });
       var inputs = [];
@@ -364,7 +364,7 @@ function lookupCapabilities(capability, options, operations, devices) {
       var ops = Object.keys(operations);
       // debug("Supp", ops);
       var supported = [];
-      ops.forEach(function(key) {
+      ops.forEach(function (key) {
         if (key === "thermostatModeOFF" || key === "upperSetpoint" || key === "lowerSetpoint" || key === "targetSetpoint") {
           if (key.substring(0, 14) === "thermostatMode") {
             key = "thermostatMode";
@@ -502,61 +502,61 @@ function lookupCapabilities(capability, options, operations, devices) {
           },
           "semantics": {
             "actionMappings": [{
-                "@type": "ActionsToDirective",
-                "actions": ["Alexa.Actions.Close"],
-                "directive": {
-                  "name": "SetRangeValue",
-                  "payload": {
-                    "rangeValue": 0
-                  }
-                }
-              },
-              {
-                "@type": "ActionsToDirective",
-                "actions": ["Alexa.Actions.Open"],
-                "directive": {
-                  "name": "SetRangeValue",
-                  "payload": {
-                    "rangeValue": devices.maxValue
-                  }
-                }
-              },
-              {
-                "@type": "ActionsToDirective",
-                "actions": ["Alexa.Actions.Lower"],
-                "directive": {
-                  "name": "AdjustRangeValue",
-                  "payload": {
-                    "rangeValueDelta": -10,
-                    "rangeValueDeltaDefault": false
-                  }
-                }
-              },
-              {
-                "@type": "ActionsToDirective",
-                "actions": ["Alexa.Actions.Raise"],
-                "directive": {
-                  "name": "AdjustRangeValue",
-                  "payload": {
-                    "rangeValueDelta": 10,
-                    "rangeValueDeltaDefault": false
-                  }
+              "@type": "ActionsToDirective",
+              "actions": ["Alexa.Actions.Close"],
+              "directive": {
+                "name": "SetRangeValue",
+                "payload": {
+                  "rangeValue": 0
                 }
               }
+            },
+            {
+              "@type": "ActionsToDirective",
+              "actions": ["Alexa.Actions.Open"],
+              "directive": {
+                "name": "SetRangeValue",
+                "payload": {
+                  "rangeValue": devices.maxValue
+                }
+              }
+            },
+            {
+              "@type": "ActionsToDirective",
+              "actions": ["Alexa.Actions.Lower"],
+              "directive": {
+                "name": "AdjustRangeValue",
+                "payload": {
+                  "rangeValueDelta": -10,
+                  "rangeValueDeltaDefault": false
+                }
+              }
+            },
+            {
+              "@type": "ActionsToDirective",
+              "actions": ["Alexa.Actions.Raise"],
+              "directive": {
+                "name": "AdjustRangeValue",
+                "payload": {
+                  "rangeValueDelta": 10,
+                  "rangeValueDeltaDefault": false
+                }
+              }
+            }
             ],
             "stateMappings": [{
-                "@type": "StatesToValue",
-                "states": ["Alexa.States.Closed"],
-                "value": devices.minValue
-              },
-              {
-                "@type": "StatesToRange",
-                "states": ["Alexa.States.Open"],
-                "range": {
-                  "minimumValue": 1,
-                  "maximumValue": devices.maxValue
-                }
+              "@type": "StatesToValue",
+              "states": ["Alexa.States.Closed"],
+              "value": devices.minValue
+            },
+            {
+              "@type": "StatesToRange",
+              "states": ["Alexa.States.Open"],
+              "range": {
+                "minimumValue": 1,
+                "maximumValue": devices.maxValue
               }
+            }
             ]
           }
         });
@@ -615,61 +615,61 @@ function lookupCapabilities(capability, options, operations, devices) {
           "configuration": {
             "ordered": false,
             "supportedModes": [{
-                "value": "Position.Up",
-                "modeResources": {
-                  "friendlyNames": [{
-                    "@type": "asset",
-                    "value": {
-                      "assetId": "Alexa.Value.Open"
-                    }
-                  }]
-                }
-              },
-              {
-                "value": "Position.Down",
-                "modeResources": {
-                  "friendlyNames": [{
-                    "@type": "asset",
-                    "value": {
-                      "assetId": "Alexa.Value.Close"
-                    }
-                  }]
-                }
+              "value": "Position.Up",
+              "modeResources": {
+                "friendlyNames": [{
+                  "@type": "asset",
+                  "value": {
+                    "assetId": "Alexa.Value.Open"
+                  }
+                }]
               }
+            },
+            {
+              "value": "Position.Down",
+              "modeResources": {
+                "friendlyNames": [{
+                  "@type": "asset",
+                  "value": {
+                    "assetId": "Alexa.Value.Close"
+                  }
+                }]
+              }
+            }
             ]
           },
           "semantics": {
             "actionMappings": [{
-                "@type": "ActionsToDirective",
-                "actions": ["Alexa.Actions.Close", "Alexa.Actions.Lower"],
-                "directive": {
-                  "name": "SetMode",
-                  "payload": {
-                    "mode": "Position.Down"
-                  }
-                }
-              },
-              {
-                "@type": "ActionsToDirective",
-                "actions": ["Alexa.Actions.Open", "Alexa.Actions.Raise"],
-                "directive": {
-                  "name": "SetMode",
-                  "payload": {
-                    "mode": "Position.Up"
-                  }
+              "@type": "ActionsToDirective",
+              "actions": ["Alexa.Actions.Close", "Alexa.Actions.Lower"],
+              "directive": {
+                "name": "SetMode",
+                "payload": {
+                  "mode": "Position.Down"
                 }
               }
+            },
+            {
+              "@type": "ActionsToDirective",
+              "actions": ["Alexa.Actions.Open", "Alexa.Actions.Raise"],
+              "directive": {
+                "name": "SetMode",
+                "payload": {
+                  "mode": "Position.Up"
+                }
+              }
+            }
             ],
             "stateMappings": [{
-                "@type": "StatesToValue",
-                "states": ["Alexa.States.Closed"],
-                "value": "Position.Down"
-              },
-              {
-                "@type": "StatesToValue",
-                "states": ["Alexa.States.Open"],
-                "value": "Position.Up"
-              }
+              "@type": "StatesToValue",
+              "states": ["Alexa.States.Closed"],
+              "value": "Position.Down"
+            },
+            {
+              "@type": "StatesToValue",
+              "states": ["Alexa.States.Open"],
+              "value": "Position.Up"
+            }
             ]
           }
         });
@@ -891,7 +891,7 @@ function normalizeName(id) {
     case "000000D9": // Service "Input Source"
       return ("Input Source");
     default:
-      // debug("Missing HB Type", id);
+    // debug("Missing HB Type", id);
   }
 }
 
@@ -1070,14 +1070,14 @@ function round(value, precision) {
 function inputs(options, accessories) {
   // Create input controller Object
 
-  options.inputs.forEach(function(input) {
+  options.inputs.forEach(function (input) {
     // debug("Input", input);
     var inputs = [];
     var cookies = {};
 
     // Find endpoint that should be part of the input
 
-    input.devices.forEach(function(device) {
+    input.devices.forEach(function (device) {
       // debug("Device", device);
 
       cookies = Object.assign(cookies, _getCookie(device, accessories));
@@ -1096,7 +1096,7 @@ function inputs(options, accessories) {
 function channel(options, accessories) {
   // Create input controller Object
 
-  options.channel.forEach(function(input) {
+  options.channel.forEach(function (input) {
     // debug("Input", input);
     // var inputs = [];
     var cookies = {};
@@ -1121,7 +1121,7 @@ function combine(options, accessories) {
     combine = options.combine;
   }
   debug("Combine-2", Array.isArray(combine), combine);
-  combine.forEach(function(combine) {
+  combine.forEach(function (combine) {
     var from = [];
     var target;
 
@@ -1132,7 +1132,7 @@ function combine(options, accessories) {
       if (combine.into === accessories.event.payload.endpoints[endpoint].friendlyName) {
         target = endpoint;
       }
-      combine.from.forEach(function(unit) {
+      combine.from.forEach(function (unit) {
         // debug("unit", unit);
         if (unit === accessories.event.payload.endpoints[endpoint].friendlyName) {
           from.push(accessories.event.payload.endpoints[endpoint]);
@@ -1154,11 +1154,11 @@ function combine(options, accessories) {
     //    console.log("ERROR: combine settings problem");
   });
   if (cleanup.length > 0) {
-    cleanup.forEach(function(endpoint) {
+    cleanup.forEach(function (endpoint) {
       delete accessories.event.payload.endpoints[endpoint];
     });
     // debug(JSON.stringify(accessories.event.payload.endpoints));
-    accessories.event.payload.endpoints = accessories.event.payload.endpoints.filter(function(e) {
+    accessories.event.payload.endpoints = accessories.event.payload.endpoints.filter(function (e) {
       return e;
     });
   }
@@ -1332,7 +1332,7 @@ function _getValue(element, hbResponse, i) {
 */
 
 function _combineAlexaDevices(into, from) {
-  from.forEach(function(device) {
+  from.forEach(function (device) {
     // debug('\nFrom', device.friendlyName);
     // Combine Cookies
     for (var cookie in device.cookie) {
@@ -1362,7 +1362,7 @@ function _combineAlexaDevices(into, from) {
       }
     } // Finshed combining cookies, now need to combine capabilities
     // Combine capabilities
-    device.capabilities.forEach(function(capability) {
+    device.capabilities.forEach(function (capability) {
       if (capability.interface !== 'Alexa') {
         debug('Combining capability', device.friendlyName, capability.interface);
         if (!_existingCapability(into.capabilities, capability)) {
@@ -1437,6 +1437,9 @@ function checkEventDeviceList(endpoints) {
       }
     }
     return (response);
+  } else if (['none'].includes(this.deviceListHandling)) {
+    debug("INFO: DeviceList - none");
+    return endpoints;
   } else {
     debug("INFO: DeviceList empty feature not enabled or config error in deviceListHandling");
     return endpoints;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "nodemonConfig": {
     "watch": [],
-    "ext": "js",
+    "ext": "js,json",
     "ignore": [],
     "exec": "~/npm/bin/homebridge -D -R -P ~/Code",
     "signal": "SIGTERM",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-alexa",
-  "version": "0.5.63-beta.4",
+  "version": "0.5.63-beta.5",
   "description": "Control your Homebridge devices with Amazon Alexa.",
   "main": "plugin.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-alexa",
-  "version": "0.5.63-beta.5",
+  "version": "0.5.63-beta.6",
   "description": "Control your Homebridge devices with Amazon Alexa.",
   "main": "plugin.js",
   "scripts": {
@@ -37,11 +37,11 @@
     "nodemon": "^2.0.4"
   },
   "dependencies": {
-    "bottleneck": ">=2.19.5",
-    "debug": ">=4.3.3",
-    "hap-node-client": ">=0.1.29",
-    "is-my-json-valid": ">=2.20.6",
-    "mqtt": "4.3.7"
+    "bottleneck": "^2.19.5",
+    "debug": "^4.3.4",
+    "hap-node-client": ">=0.1.30-beta.0",
+    "is-my-json-valid": "^2.20.6",
+    "mqtt": "^4.3.7"
   },
   "author": "NorthernMan54",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-alexa",
-  "version": "0.5.63-beta.6",
+  "version": "0.5.63-beta.7",
   "description": "Control your Homebridge devices with Amazon Alexa.",
   "main": "plugin.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-alexa",
-  "version": "0.5.63-beta.8",
+  "version": "0.5.63-beta.9",
   "description": "Control your Homebridge devices with Amazon Alexa.",
   "main": "plugin.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "api": "documentation build plugin.js lib/alexaActions.js lib/alexaLocal.js lib/alexaMessages.js lib/alexaTranslator.js -f md --config docs/documentation.yml > docs/API.md",
-    "document": "./gh-md-toc --insert README.md;./gh-md-toc --insert Troubleshooting.md;./gh-md-toc --insert Installation.md",
+    "document": "./gh-md-toc --insert README.md;./gh-md-toc --insert Troubleshooting.md;./gh-md-toc --insert Installation.md; rm README.md.orig.* README.md.toc.* Troubleshooting.md.orig.* Troubleshooting.md.toc.* Installation.md.orig.* Installation.md.toc.*",
     "watch": "nodemon"
   },
   "nodemonConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-alexa",
-  "version": "0.5.63-beta.9",
+  "version": "0.6.0-beta.9",
   "description": "Control your Homebridge devices with Amazon Alexa.",
   "main": "plugin.js",
   "scripts": {
@@ -39,7 +39,7 @@
   "dependencies": {
     "bottleneck": "^2.19.5",
     "debug": "^4.3.4",
-    "hap-node-client": ">=0.1.30-beta.0",
+    "hap-node-client": "^0.2.0",
     "is-my-json-valid": "^2.20.6",
     "mqtt": "^4.3.7"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-alexa",
-  "version": "0.5.63-beta.7",
+  "version": "0.5.63-beta.8",
   "description": "Control your Homebridge devices with Amazon Alexa.",
   "main": "plugin.js",
   "scripts": {


### PR DESCRIPTION
- Added additional debug logging to easily determine child bridge address to aid Homebridge Accessory Dumps
- Updates to hap-node-client to better support usage of ipv6 and removal of request dependancy
- Update to gh-md-toc ( generates TOC for README )
- Merge current beta functionality into main code base
- Enable ability to change cloud transport `CloudTransport`, to provide improved connectivity in some setups. Previously these had been available in the beta.
- Removed the Alexa contact sensor ( which shows the status of the connection to the cloud servers ) from the list of devices passed to Alexa.
- Updated and simplified the Homebridge-UI plugin settings menu for homebridge-alexa