### PR TITLE
Enabls HK Thermostat type accessory to turn off

### DIFF
--- a/lib/parse/Characteristic.js
+++ b/lib/parse/Characteristic.js
@@ -259,9 +259,11 @@ function _getActions(description, context, devices) {
       //  cookie["targetSetpoint"] = messages.cookie(context);
       // }
       break;
+    case "Target Heating Cooling State":
+      cookie["TurnOn"] = messages.cookieV(2, context);	// COOL
+      cookie["TurnOff"] = messages.cookieV(0, context);	// OFF
     case "Target Heater-Cooler State":
     case "Target Heater Cooler State":
-    case "Target Heating Cooling State":
       reportState.push(messages.reportState("Alexa.ThermostatControllerthermostatMode", context));
       // reportState.push(messages.reportState("Alexa.ThermostatController", context));
       // Characteristic.TargetHeatingCoolingState.OFF = 0;

--- a/lib/parse/Service.js
+++ b/lib/parse/Service.js
@@ -219,8 +219,9 @@ Service.prototype.toAlexa = function (context) {
           capabilities = capabilities.concat(messages.lookupCapabilities("ColorController", context.events));
         }
         break;
-      case "Heater Cooler":
       case "Thermostat":
+        capabilities = capabilities.concat(messages.lookupCapabilities("Active", context.events, cookie));
+      case "Heater Cooler":
         /*
         reportState.push({
           "interface": "Alexa.ThermostatController",

--- a/lib/parse/messages.js
+++ b/lib/parse/messages.js
@@ -227,6 +227,15 @@ function stateToProperties(statusObject, hbResponse) {
           "timeOfSample": now.toISOString(),
           "uncertaintyInMilliseconds": 500
         });
+        if (!statusObject.elements.find(x => x.interface.toLowerCase() === "alexa.powercontroller")) {
+          properties.push({
+            "namespace": "Alexa.PowerController",
+            "name": "powerState",
+            "value": properties[0].value === "OFF" ? "OFF" : "ON",
+            "timeOfSample": now.toISOString(),
+            "uncertaintyInMilliseconds": 500
+          });
+	}
         break;
       default:
         debug("ERROR: statusReport unknown/handled device", element, reportState);


### PR DESCRIPTION
This PR enables turning HK thermostat type accessories to OFF.

I was wondering and frustrated that there's no way for turning HK thermostat type accessories to OFF from day 1. I think this not limited on my environment, as shown in https://github.com/NorthernMan54/homebridge-alexa/wiki/Thermostat-Voice-Control-Comparison.

Reentry I found an Amazon document describing that this is an intended behavior, and recommends to implement PowerController for air conditioners.

https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-thermostatcontroller.html#discover-response-example-for-an-air-conditioner

According to the document, this PR adds PowerController entries for discover, response, and stateReport for HK thermostat services to enable turning them ON/OFF. Turning ON is internally interpreted as COOL as in homebridge-gsh.

Currently, this is working well in my environment, and I hope anyone try to see if any issues or side effects.